### PR TITLE
Added complex tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,21 @@ const specs = [
     description: 'Array test 3',
     before: 'bar[hoge].isNil',
     after: `"use strict";\n\n${helper}\n\n_isNilWrapper(bar[hoge]);`
+  },
+  {
+    description: 'Complex test 1',
+    before: 'foo.bar.hoge("poge")[1].bar.isNil',
+    after: `"use strict";\n\n${helper}\n\n_isNilWrapper(foo.bar.hoge("poge")[1].bar);`
+  },
+  {
+    description: 'Complex test 2',
+    before: 'foo.bar["hoge"]["poge"].foo[bar][2].isNil',
+    after: `"use strict";\n\n${helper}\n\n_isNilWrapper(foo.bar["hoge"]["poge"].foo[bar][2]);`
+  },
+  {
+    description: 'Complex test 3',
+    before: '(hoge.poge || { }).foo.bar["hoge"][3].poge.isNil',
+    after: `"use strict";\n\n${helper}\n\n_isNilWrapper((hoge.poge || { }).foo.bar[3]["hoge"].poge);`
   }
 ]
 


### PR DESCRIPTION
I added a few complex tests:

```js
foo.bar.hoge("poge")[1].bar.isNil
foo.bar["hoge"]["poge"].foo[bar][2].isNil
(hoge.poge || { }).foo.bar["hoge"][3].poge.isNil
```

The tests are failing as the compiled output is:

```js
_isNilWrapper(foo.bar.hoge.bar)
_isNilWrapper(foo.bar.foo.bar[2])
_isNilWrapper(hoge.poge.foo.bar.poge)
```

When they should be:

```js
_isNilWrapper(foo.bar.hoge("poge")[1].bar)
_isNilWrapper(foo.bar["hoge"]["poge"].foo[bar][2])
_isNilWrapper((hoge.poge || { }).foo.bar[3]["hoge"].poge)
```

I don‘t know how to fix these myself, but these scenarios should compile to the original code.